### PR TITLE
ci: exécuter les suites de tests des packs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,95 @@
+name: "Tests"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# Minimal permissions following least privilege principle
+permissions:
+  contents: read
+
+# A push that supersedes an in-flight run makes that run's answer worthless;
+# 17 packs x a full dependency install is the last thing to leave running for
+# a commit nobody will merge.
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Testing all 17 packs on every commit means 17 dependency installs, most of
+  # them for packs the change cannot reach. This job narrows the matrix to the
+  # packs actually touched; anything shared (scripts/, .github/, root config)
+  # still fans out to everything.
+  select:
+    name: Select packs to test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      packs: ${{ steps.pick.outputs.packs }}
+      any: ${{ steps.pick.outputs.any }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0  # the diff needs the base commit, not just HEAD
+
+      - name: Pick the packs this change can affect
+        id: pick
+        env:
+          BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ -n "$BASE" ] && git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+            packs=$(git diff --name-only "$BASE" HEAD | scripts/select_test_matrix.sh)
+          else
+            # New branch, force-push, or a first commit: `before` is the null
+            # SHA and there is nothing to diff against. Test everything rather
+            # than silently test nothing.
+            echo "no usable base ref ('$BASE'), selecting every pack"
+            packs=$(scripts/select_test_matrix.sh --all)
+          fi
+          echo "packs=$packs" >> "$GITHUB_OUTPUT"
+          if [ "$packs" = "[]" ]; then
+            echo "any=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Selected: $packs" >> "$GITHUB_STEP_SUMMARY"
+
+  test:
+    name: Pytest - ${{ matrix.pack }}
+    needs: select
+    if: needs.select.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      # One broken pack must not hide the state of the other sixteen.
+      fail-fast: false
+      matrix:
+        pack: ${{ fromJSON(needs.select.outputs.packs) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "${{ matrix.pack }}/uv.lock"
+
+      - name: Install the pack's locked dependencies
+        working-directory: ${{ matrix.pack }}
+        # --frozen: test what the worker will actually install, and fail if the
+        # lockfile drifted from pyproject.toml instead of quietly re-resolving.
+        # --no-install-project: a pack is a main.py the worker runs, not an
+        # installable distribution — hatchling has no package to build here.
+        run: |
+          set -euo pipefail
+          uv sync --frozen --no-install-project
+          uv pip install pytest
+
+      - name: Run tests
+        working-directory: ${{ matrix.pack }}
+        run: .venv/bin/python -m pytest tests -q

--- a/scripts/select_test_matrix.sh
+++ b/scripts/select_test_matrix.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Emit the JSON matrix of packs whose test suite CI should run.
+#
+# Reads changed file paths on stdin (one per line), writes a JSON array of pack
+# directory names on stdout. With --all, ignores stdin and selects everything.
+#
+# A change outside any *_pack/ directory — scripts/, .github/, root config —
+# can affect every pack, so it selects all of them. Erring the other way would
+# let a change to this very script, or to a shared helper, ship untested.
+#
+# Packs without a pyproject.toml, or without a tests/test_*.py, are never
+# selected: pytest exits 5 on an empty collection, which would fail the job for
+# a pack that simply has no suite yet. Removing a pack's last test therefore
+# makes it silently unwatched rather than red — scripts/lint_packs.sh is the
+# thing that still sees it.
+#
+# Usable outside CI: `git diff --name-only main | scripts/select_test_matrix.sh`
+set -euo pipefail
+shopt -s nullglob
+
+cd "$(dirname "$0")/.."
+
+testable() {
+  local pack="$1"
+  [ -f "$pack/pyproject.toml" ] || return 1
+  local matches=("$pack"/tests/test_*.py)
+  [ ${#matches[@]} -gt 0 ]
+}
+
+all_testable() {
+  local dir pack
+  for dir in */; do
+    pack="${dir%/}"
+    if testable "$pack"; then
+      echo "$pack"
+    fi
+  done
+}
+
+emit() {
+  # jq is present on GitHub runners and in the devcontainer; sort -u keeps the
+  # matrix stable so a rerun does not reshuffle job names.
+  sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))'
+}
+
+if [ "${1:-}" = "--all" ]; then
+  all_testable | emit
+  exit 0
+fi
+
+shared=0
+selected=()
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  case "$path" in
+    *_pack/*) selected+=("${path%%/*}") ;;
+    *) shared=1 ;;
+  esac
+done
+
+if [ "$shared" -eq 1 ]; then
+  all_testable | emit
+  exit 0
+fi
+
+{
+  for pack in ${selected[@]+"${selected[@]}"}; do
+    if testable "$pack"; then
+      echo "$pack"
+    fi
+  done
+} | emit


### PR DESCRIPTION
Ce repo n'avait **aucun job de test**. `ci-security.yml` fait CodeQL et la détection de secrets, `publish.yml` résout et publie. Les 244 tests des packs existaient et rien ne les rejouait : une régression pouvait atteindre la plateforme avec tous les checks au vert.

## Le coût, qui est la raison pour laquelle ça n'existait pas

Tester les 17 packs à chaque commit, c'est 17 installations de dépendances, dont la plupart pour des packs que le changement ne peut pas atteindre. Trois mécanismes ramènent ça près de zéro :

- **`scripts/select_test_matrix.sh`** réduit la matrice aux packs réellement touchés. Un changement partagé (`scripts/`, `.github/`, config racine) refait tout — on ne se trompe dans le sens coûteux que là où un changement peut vraiment atteindre chaque pack.
- **cache uv** indexé sur le `uv.lock` de chaque pack.
- **`cancel-in-progress`** : un push qui en périme un autre rend sa réponse inutile.

Une PR ordinaire sur un seul pack coûte **un job**. Celle-ci touche `.github/`, donc elle éventaille sur les 16 packs — ce qui est exactement l'exercice qu'on veut pour la première mise en service.

## Détails qui comptent

`uv sync --frozen --no-install-project` :
- `--frozen` teste ce que le worker installera vraiment, et échoue si le lockfile a dérivé du `pyproject.toml` au lieu de re-résoudre en douce.
- `--no-install-project` parce qu'un pack est un `main.py` que le worker exécute, pas une distribution installable — hatchling n'a rien à construire.

**16 packs sélectionnés, pas 17** : `dbt_checks_pack` n'a aucun `tests/test_*.py`. Le script exclut ces packs parce que pytest sort en code 5 sur une collecte vide et ferait échouer le job d'un pack qui n'a simplement pas encore de suite. Conséquence assumée et documentée dans le script : retirer le dernier test d'un pack le rend **silencieusement non surveillé** plutôt que rouge. `scripts/lint_packs.sh` reste ce qui le voit.

`fail-fast: false` — un pack cassé ne doit pas masquer l'état des seize autres.

Le script lit les chemins modifiés sur stdin, donc il s'utilise hors CI :

```
git diff --name-only main | scripts/select_test_matrix.sh
```

Vérifié localement : un pack touché → `["profiling_pack"]` ; deux packs dont un sans tests → les deux testables seulement ; fichier partagé → 16 ; entrée vide → `[]` et le job `test` est skippé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
