### PR TITLE
chore: verrouiller qalita-core 2.1.0

### DIFF
--- a/accuracy_pack/uv.lock
+++ b/accuracy_pack/uv.lock
@@ -2298,7 +2298,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -2330,9 +2330,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/data_compare_pack/uv.lock
+++ b/data_compare_pack/uv.lock
@@ -2235,7 +2235,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -2267,9 +2267,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/data_drift_pack/uv.lock
+++ b/data_drift_pack/uv.lock
@@ -1486,7 +1486,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -1518,9 +1518,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/dbt_checks_pack/uv.lock
+++ b/dbt_checks_pack/uv.lock
@@ -1480,7 +1480,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -1512,9 +1512,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/duplicates_finder_pack/uv.lock
+++ b/duplicates_finder_pack/uv.lock
@@ -2249,7 +2249,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -2281,9 +2281,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/fhir_compliance_pack/uv.lock
+++ b/fhir_compliance_pack/uv.lock
@@ -1486,7 +1486,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -1518,9 +1518,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/great_expectations_pack/uv.lock
+++ b/great_expectations_pack/uv.lock
@@ -1755,7 +1755,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -1787,9 +1787,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/numeric_validation_pack/uv.lock
+++ b/numeric_validation_pack/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -2518,9 +2518,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/omop_cdm_pack/uv.lock
+++ b/omop_cdm_pack/uv.lock
@@ -1513,7 +1513,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -1545,9 +1545,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/outlier_detection_pack/uv.lock
+++ b/outlier_detection_pack/uv.lock
@@ -2298,7 +2298,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -2330,9 +2330,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/pattern_validation_pack/uv.lock
+++ b/pattern_validation_pack/uv.lock
@@ -2284,7 +2284,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -2316,9 +2316,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/pii_scanner_pack/uv.lock
+++ b/pii_scanner_pack/uv.lock
@@ -2247,7 +2247,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -2279,9 +2279,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/profiling_pack/uv.lock
+++ b/profiling_pack/uv.lock
@@ -1205,7 +1205,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -1237,9 +1237,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/referential_integrity_pack/uv.lock
+++ b/referential_integrity_pack/uv.lock
@@ -1469,7 +1469,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -1501,9 +1501,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/schema_scanner_pack/uv.lock
+++ b/schema_scanner_pack/uv.lock
@@ -2139,7 +2139,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -2171,9 +2171,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/soda_pack/uv.lock
+++ b/soda_pack/uv.lock
@@ -2280,7 +2280,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -2312,9 +2312,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/text_validation_pack/uv.lock
+++ b/text_validation_pack/uv.lock
@@ -2216,7 +2216,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -2248,9 +2248,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]

--- a/timeliness_pack/uv.lock
+++ b/timeliness_pack/uv.lock
@@ -2230,7 +2230,7 @@ wheels = [
 
 [[package]]
 name = "qalita-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-storage-blob" },
@@ -2262,9 +2262,9 @@ dependencies = [
     { name = "teradatasqlalchemy" },
     { name = "trino" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/bb2d7246d53c2fd7689168c19936e1470f5e5a897489cbd3cad017ad6478/qalita_core-2.0.0.tar.gz", hash = "sha256:644ef46eae299991c28ef72eea55e004a9d1328e461068af3df74621465cfaf2", size = 1556417, upload-time = "2026-08-03T13:45:16.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ea/be36dbc3cae59527c6c9ad1c2b72189c7d0158c5a6f59e2353ab26136544/qalita_core-2.1.0.tar.gz", hash = "sha256:f2b249492c4fed3eaf68eecdeec57fc0ecd6cbae21ee27343885b3136b8ee09d", size = 1562979, upload-time = "2026-08-03T14:52:37.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/3f/88452b5968bd4d0f3bedb493680f8a7aace0ded63cff1cd5d1d6bf0ccb45/qalita_core-2.0.0-py3-none-any.whl", hash = "sha256:b928db4808024a9cad07e2a8a99d032dc6cdf637677f5539397614b999e953df", size = 79233, upload-time = "2026-08-03T13:45:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d4/74d8e0e007c6149b5c509b93cd0e581e66a2a6cdfa2ecbf769ca6799d44a/qalita_core-2.1.0-py3-none-any.whl", hash = "sha256:4a7d59d2977e0cfa322089167007459e10c05c55eaea2504183cc2e16e3fe670", size = 81238, upload-time = "2026-08-03T14:52:36.298Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fait arriver les correctifs de fidélité du loader sur les workers. Le tag seul ne suffit pas : les 18 packs figeaient `qalita-core 2.0.0` dans leurs lockfiles.

Ce que ça embarque :

- `DECIMAL`/`NUMERIC` arrivent en `pl.Decimal` au lieu d'être arrondis via `float` — **changement de dtype observable**, d'où le mineur et pas le patch
- `iter_json_array` ne rend plus de valeurs tronquées
- JSON lu en `utf-8-sig` (BOM)
- `S3Source` n'envoie plus la clé de l'objet comme `aws_access_key_id`
- le staging distant vérifie l'espace libre et désambiguïse les basenames qui collident

## Un piège à connaître

`uv lock` tout court **ne change rien** : `2.0.0` satisfait toujours `>=2.0.0`, donc uv garde le pin existant et sort « Resolved 18 packages » en ayant fait un no-op. Il faut `uv lock --upgrade-package qalita-core`. Sans ça cette PR aurait été vide et la release n'aurait atteint aucun worker — avec une CI parfaitement verte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)